### PR TITLE
virus-vaccine-21 로그 설정 (slf4j / log4j2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+logs/
 
 ### local properties file
 src/main/resources/application-local.yml

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,13 @@ repositories {
     mavenCentral()
 }
 
+configurations {
+    all{
+        // spring-boot-starter-web에 포함 된 logback 설정을 제거
+        exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
+    }
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
@@ -22,6 +29,8 @@ dependencies {
     implementation 'junit:junit:4.13.1'
     implementation 'com.google.guava:guava:30.1.1-jre'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation 'org.springframework.boot:spring-boot-starter-log4j2'
+
 }
 
 test {

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<Configuration status="INFO">
+  <Properties>
+    <Property name="LOG_PATTERN">%d{HH:mm:ss.SSSZ} [%t] %-5level %logger{36} - %msg%n</Property>
+  </Properties>
+  <Appenders>
+    <Console name="console" target="SYSTEM_OUT">
+      <PatternLayout pattern="${LOG_PATTERN}" charset="UTF-8"/>
+    </Console>
+    <RollingFile name="file"
+                 fileName="./logs/spring.log"
+                 filePattern="./logs/spring-%d{yyyy-MM-dd}-%i.log">
+      <PatternLayout pattern="${LOG_PATTERN}" charset="UTF-8" />
+      <Policies>
+        <TimeBasedTriggeringPolicy interval="1" />
+        <SizeBasedTriggeringPolicy size="10000KB" />
+      </Policies>
+      <DefaultRolloverStrategy max="20" fileIndex="min" />
+    </RollingFile>
+  </Appenders>
+  <Loggers>
+    <Root level="debug">
+      <AppenderRef ref="console"/>
+      <AppenderRef ref="file"/>
+    </Root>
+    <logger name="org.springframework" level="info" additivity="false" >
+      <AppenderRef ref="console" />
+      <AppenderRef ref="file" />
+    </logger>
+    <logger name="com.virusvaccine" additivity="false" >
+      <AppenderRef ref="console" level="info" />
+      <AppenderRef ref="file" level="debug" />
+    </logger>
+  </Loggers>
+</Configuration>

--- a/src/test/java/com/virusvaccine/VirusVaccineApplicationTests.java
+++ b/src/test/java/com/virusvaccine/VirusVaccineApplicationTests.java
@@ -1,13 +1,24 @@
 package com.virusvaccine;
 
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 class VirusVaccineApplicationTests {
 
+    private static final Logger logger = LoggerFactory.getLogger(VirusVaccineApplicationTests.class);
+
     @Test
     void contextLoads() {
+    }
+
+    @Test
+    void logTest(){
+        logger.debug("this is debug, displayed on the log file.");
+        logger.info("this is info, displayed on the console and log file.");
+        logger.error("this is error, displayed on the console and log file.");
     }
 
 }


### PR DESCRIPTION
slf4j + log4j2 설정
 - 기본 설정은 debug 로 console과 logfile에 표시
 - org.springframework 하위의 info 는 console과 logfile에 표시
 - com.virusvaccine 하위의 debug log는 logfile에만 표시
 - logfile 은 classpath://logs/spring.log로 저장 (.gitignore 추가)
 - rolling은 1일, 10MB 기준, DefaultRolloverStrategy의 max를 10, fileindex를 min으로 설정
 - rolling file 패턴 `./logs/spring-%d{yyyy-MM-dd}-%i.log`