### PR TITLE
[#38] 로그인체크 및 권한체크 로직 수정

### DIFF
--- a/src/main/java/com/virusvaccine/common/config/RedisConfig.java
+++ b/src/main/java/com/virusvaccine/common/config/RedisConfig.java
@@ -31,3 +31,5 @@ public class RedisConfig {
   }
 
 }
+
+

--- a/src/main/java/com/virusvaccine/common/interceptor/AuthInterceptor.java
+++ b/src/main/java/com/virusvaccine/common/interceptor/AuthInterceptor.java
@@ -1,6 +1,7 @@
 package com.virusvaccine.common.interceptor;
 
 import com.virusvaccine.common.annotation.Authorized;
+import com.virusvaccine.common.exception.NotFoundException;
 import com.virusvaccine.common.exception.NotLoginException;
 import com.virusvaccine.common.exception.UnauthorizedException;
 import com.virusvaccine.user.service.AccountService.Role;
@@ -34,10 +35,11 @@ public class AuthInterceptor implements HandlerInterceptor {
     }
 
     private Role getSessionRole(HttpServletRequest request){
-        HttpSession session = request.getSession();
-        Object role = session.getAttribute(SESSION_KEY_ROLE);
-        if (role == null)
+        HttpSession session = request.getSession(false);
+        if (session == null){
             throw new NotLoginException();
+        }
+        Object role = session.getAttribute(SESSION_KEY_ROLE);
 
         return (Role) role;
     }

--- a/src/main/java/com/virusvaccine/common/resolver/AccountIdArgumentResolver.java
+++ b/src/main/java/com/virusvaccine/common/resolver/AccountIdArgumentResolver.java
@@ -30,9 +30,6 @@ public class AccountIdArgumentResolver implements HandlerMethodArgumentResolver 
     public Long resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
         Object accountId = session.getAttribute(SESSION_KEY_USER);
 
-        if (accountId == null) {
-            throw new UnauthorizedException();
-        }
 
         return (Long) accountId;
     }

--- a/src/main/java/com/virusvaccine/user/controller/UserController.java
+++ b/src/main/java/com/virusvaccine/user/controller/UserController.java
@@ -31,6 +31,7 @@ public class UserController {
 
         if (!signUpRequest.validatePassword())
             throw new NotIdenticalPasswordException();
+
         accountService.signUp(signUpRequest);
 
         return new ResponseEntity<>(HttpStatus.OK);


### PR DESCRIPTION
1. 로그인 체크하는 기능 수정
2. HandlerMethodArgumentResolver 에서 권한체크 하는 부분 제거 (핸들러 인터셉터에서 이미 적용되므로 권한이 다른경우 리졸버에 도달하지도 않는다고 판단)